### PR TITLE
Add Edit File Functionality

### DIFF
--- a/assets/scripts/uploads/api.js
+++ b/assets/scripts/uploads/api.js
@@ -33,8 +33,21 @@ const getUploads = function () {
   })
 }
 
+const editUpload = function (id, data) {
+  const token = store.user.token
+  return $.ajax({
+    url: config.apiOrigin + '/uploads/' + id,
+    method: 'PATCH',
+    headers: {
+      authorization: 'Token token=' + token
+    },
+    data
+  })
+}
+
 module.exports = {
   createEnc,
   createMulti,
-  getUploads
+  getUploads,
+  editUpload
 }

--- a/assets/scripts/uploads/ui.js
+++ b/assets/scripts/uploads/ui.js
@@ -18,10 +18,64 @@ const error = function (error) {
 const onGetUploadsSuccess = function (data) {
   const showUploadsHtml = showUploadsTemplate({ uploads: data.uploads })
   $('.uploads-table').append(showUploadsHtml)
+  $('.edit-btn').on('click', onEditUpload)
 }
 
 const onGetUploadsFailure = function (error) {
   console.error(error)
+}
+
+const onEditUpload = function () {
+  const elementId = $(this).parent().parent().attr('data-id')
+  const fileName = $(this).parent().siblings()[0]
+  const tags = $(this).parent().siblings()[4]
+  fileName.contentEditable = true
+  tags.contentEditable = true
+  $(fileName).css('background-color', 'rgba(255, 255, 0, 0.5)') // Show user editable fields
+  $(tags).css('background-color', 'rgba(255, 255, 0, 0.5)')
+  $(fileName).keydown(function (e) { // Prevent user from adding new lines in table
+    if (e.which === 13) { // 13 --> enter key
+      fileName.blur()
+    }
+  })
+  $(tags).keydown(function (e) {
+    if (e.which === 13) {
+      tags.blur()
+    }
+  })
+  $(this).next().hide() // Hide delete button
+  $(this).parent().append('<button class="btn btn-info confirm-edit-btn">Confirm</button>')
+  $(this).hide() // Hide edit button
+  $('.confirm-edit-btn').on('click', function () {
+    onConfirmEdit(elementId, fileName, tags)
+  })
+}
+
+const onConfirmEdit = function (elementId, fileName, tags) {
+  const newFileName = $(fileName).html()
+  const newTags = $(tags).html()
+  const data =
+    {
+      upload: {
+        name: newFileName,
+        tags: newTags
+      }
+    }
+  api.editUpload(elementId, data)
+    .then(onEditUploadSuccess)
+    .catch(onEditUploadFailure)
+}
+
+const onEditUploadSuccess = function (data) {
+  console.log(data)
+  $('.uploads-table').html('')
+  api.getUploads()
+    .then(onGetUploadsSuccess)
+    .catch(onGetUploadsFailure)
+}
+
+const onEditUploadFailure = function (error) {
+  console.log(error)
 }
 
 module.exports = {


### PR DESCRIPTION
Add event listener for edit button, which allows a user to input a new
file name, as well as tags for a file. When a user confirms the changes,
a patch request is sent to the API, which modifies the data in MongoDB.
When this action is successful, the table automatically refreshes with
the user's changes.

Full team programming