### PR TITLE
Fixes bug on password confirmation

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -6,9 +6,14 @@ const ui = require('./ui')
 const onSignUp = function (event) {
   const data = getFormFields(this)
   event.preventDefault()
-  api.signUp(data)
-    .then(ui.signUpSuccess)
-    .catch(ui.signUpFailure)
+  if (data.credentials.password !== data.credentials.password_confirmation) {
+    ui.signUpFailure()
+  } else {
+    api.signUp(data)
+      .then(ui.signUpSuccess)
+      .catch(ui.signUpFailure)
+  }
+
 }
 
 const onSignIn = function (event) {


### PR DESCRIPTION
Add an if statement to check that on signup, the password and password
confirmation are the same before it sends a request to the API.