### PR TITLE
Add .empty() to get table function

### DIFF
--- a/assets/scripts/uploads/ui.js
+++ b/assets/scripts/uploads/ui.js
@@ -23,6 +23,7 @@ const error = function () {
 
 const onGetUploadsSuccess = function (data) {
   const showUploadsHtml = showUploadsTemplate({ uploads: data.uploads })
+  $('.uploads-table').empty()
   $('.uploads-table').append(showUploadsHtml)
   $('.edit-btn').on('click', onEditUpload)
   $('.delete-btn').on('click', onDeleteUpload)


### PR DESCRIPTION
adds .empty() before get table function to avoid duplicate tables